### PR TITLE
Tool 1218/bare

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -7,6 +7,7 @@ app:
 
   - ORIGIN_SOURCE_DIR: $BITRISE_SOURCE_DIR
   - SAMPLE_APP_URL: https://github.com/bitrise-samples/react-native-expo.git
+  - BRANCH: "SDK_34"
 
   # Define it in .bitrise.secrets.yml
   - USER_NAME: $USER_NAME
@@ -22,19 +23,17 @@ workflows:
     - errcheck:
     - go-test:
     after_run:
-    - plain
+    - bare
     - expo_kit
-    - plain_2_0_0
-    - expo_kit_2_0_0
 
-  plain:
+  bare:
     before_run:
     - _clear_workdir
     steps:
     - script:
         title: Clone sample app
         inputs:
-        - content: git clone $SAMPLE_APP_URL . && cd
+        - content: git clone $SAMPLE_APP_URL . -b $BRANCH && cd
     - npm@0.9.1:
         title: Install node modules for the expo project
         inputs:
@@ -46,25 +45,6 @@ workflows:
         - project_path: $BITRISE_SOURCE_DIR
         - expo_cli_verson: "latest"
         - override_react_native_version: 0.55.4
-
-  plain_2_0_0:
-    before_run:
-    - _clear_workdir
-    steps:
-    - script:
-        title: Clone sample app
-        inputs:
-        - content: git clone $SAMPLE_APP_URL . && cd
-    - npm@0.9.1:
-        title: Install node modules for the expo project
-        inputs:
-        - command: install
-    - path::./:
-        title: Step Test
-        run_if: true
-        inputs:
-        - project_path: $BITRISE_SOURCE_DIR
-        - expo_cli_verson: "2.0.0"
     
   expo_kit:
     before_run:
@@ -84,27 +64,6 @@ workflows:
         inputs:
         - project_path: $BITRISE_SOURCE_DIR
         - expo_cli_verson: "latest"
-        - user_name: $USER_NAME
-        - password: $PASSWORD
-
-  expo_kit_2_0_0:
-    before_run:
-    - _clear_workdir
-    steps:
-    - script:
-        title: Clone sample app
-        inputs:
-        - content: git clone -b expo_sdk $SAMPLE_APP_URL . && cd
-    - npm@0.9.1:
-        title: Install node modules for the expo project
-        inputs:
-        - command: install
-    - path::./:
-        title: Step Test
-        run_if: true
-        inputs:
-        - project_path: $BITRISE_SOURCE_DIR
-        - expo_cli_verson: "2.0.0"
         - user_name: $USER_NAME
         - password: $PASSWORD
 

--- a/main.go
+++ b/main.go
@@ -26,12 +26,12 @@ type Config struct {
 	OverrideReactNativeVersion string          `env:"override_react_native_version"`
 }
 
-// EjectMethod if the project is using Expo SDK and you choose the "plain" --eject-method those imports will stop working.
+// EjectMethod if the project is using Expo SDK and you choose the "bare" --eject-method those imports will stop working.
 type EjectMethod string
 
 // const ...
 const (
-	Plain   EjectMethod = "bare"
+	Bare    EjectMethod = "bare"
 	ExpoKit EjectMethod = "expoKit"
 )
 
@@ -169,7 +169,7 @@ func main() {
 
 	//
 	// Select the --eject-method
-	ejectMethod := Plain
+	ejectMethod := Bare
 	fmt.Println()
 	log.Infof("Define --eject-method")
 	{
@@ -207,8 +207,8 @@ func main() {
 			if err := e.login(cfg.UserName, cfg.Password); err != nil {
 				failf("Failed to log in to your provided Expo account, error: %s", err)
 			}
-		case Plain:
-			log.Printf("--eject-method has been set to plain => Skip...")
+		case Bare:
+			log.Printf("--eject-method has been set to bare => Skip...")
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ type EjectMethod string
 
 // const ...
 const (
-	Plain   EjectMethod = "plain"
+	Plain   EjectMethod = "bare"
 	ExpoKit EjectMethod = "expoKit"
 )
 

--- a/step.yml
+++ b/step.yml
@@ -38,7 +38,7 @@ inputs:
         
         A couple of examples:
         
-        * "2.0.0"
+        * "3.0.0"
         * latest
       is_required: "true"
   - user_name: ""
@@ -52,7 +52,7 @@ inputs:
         the `user_name` and `password` inputs are __required__.
 
         If you provide these inputs the step will run: `expo eject --eject-method expoKit`,  
-        otherwise: `expo eject --eject-method plain`.
+        otherwise: `expo eject --eject-method bare`.
 
         **NOTE:** You need to use your username and not your e-mail address.
   - password: ""
@@ -66,7 +66,7 @@ inputs:
         the `user_name` and `password` inputs are __required__.
 
         If you provide these inputs the step will run: `expo eject --eject-method expoKit`,  
-        otherwise: `expo eject --eject-method plain`.
+        otherwise: `expo eject --eject-method bare`.
       is_sensitive: true
   - run_publish: "no"
     opts:


### PR DESCRIPTION
Replaces the `plain` eject-method with `bare` as plain is not supported anymore with the expo-cli.

The difference is that a `bare` project is based on `expo-template-bare-minimum` and therefore includes `unimodule` support.

