### PR TITLE
[STEP-10]: Remove expo cli eject method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Expo Eject
 
-Using the The Expo Development CLI to Creates Xcode and Android Studio projects for your app.
+Use the Expo Development CLI to create Xcode and Android Studio projects for your app.
 
 
 ## How to use this Step

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Beta] Expo Eject
+# Expo Eject
 
 Using the The Expo Development CLI to Creates Xcode and Android Studio projects for your app.
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -3,115 +3,115 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 app:
   envs:
-  - BITRISE_STEP_GIT_CLONE_URL: https://github.com/bitrise-steplib/steps-expo-detach.git
+    - BITRISE_STEP_GIT_CLONE_URL: https://github.com/bitrise-steplib/steps-expo-detach.git
 
-  - ORIGIN_SOURCE_DIR: $BITRISE_SOURCE_DIR
-  - SAMPLE_APP_URL: https://github.com/bitrise-samples/react-native-expo.git
-  - BRANCH: "SDK_34"
+    - ORIGIN_SOURCE_DIR: $BITRISE_SOURCE_DIR
+    - SAMPLE_APP_URL: https://github.com/bitrise-samples/react-native-expo.git
+    - BRANCH: "SDK39"
 
-  # Define it in .bitrise.secrets.yml
-  - USER_NAME: $USER_NAME
-  - PASSWORD: $PASSWORD
+    # Define it in .bitrise.secrets.yml
+    - USER_NAME: $USER_NAME
+    - PASSWORD: $PASSWORD
 
 workflows:
   test:
     before_run:
-    - audit-this-step
+      - audit-this-step
     steps:
-    - go-list:
-    - golint:
-    - errcheck:
-    - go-test:
+      - go-list:
+      - golint:
+      - errcheck:
+      - go-test:
     after_run:
-    - bare
-    - expo_kit
+      - bare
+      - expo_kit
 
   bare:
     before_run:
-    - _clear_workdir
+      - _clear_workdir
     steps:
-    - script:
-        title: Clone sample app
-        inputs:
-        - content: git clone $SAMPLE_APP_URL . -b $BRANCH && cd
-    - npm@0.9.1:
-        title: Install node modules for the expo project
-        inputs:
-        - command: install
-    - path::./:
-        title: Step Test
-        run_if: true
-        inputs:
-        - project_path: $BITRISE_SOURCE_DIR
-        - expo_cli_verson: "latest"
-        - override_react_native_version: 0.55.4
-    
+      - script:
+          title: Clone sample app
+          inputs:
+            - content: git clone $SAMPLE_APP_URL . -b $BRANCH && cd
+      - npm@0.9.1:
+          title: Install node modules for the expo project
+          inputs:
+            - command: install
+      - path::./:
+          title: Step Test
+          run_if: true
+          inputs:
+            - project_path: $BITRISE_SOURCE_DIR
+            - expo_cli_verson: "latest"
+            - override_react_native_version: 0.61.0
+
   expo_kit:
     before_run:
-    - _clear_workdir
+      - _clear_workdir
     steps:
-    - script:
-        title: Clone sample app
-        inputs:
-        - content: git clone -b expo_sdk $SAMPLE_APP_URL . && cd
-    - npm@0.9.1:
-        title: Install node modules for the expo project
-        inputs:
-        - command: install
-    - path::./:
-        title: Step Test
-        run_if: true
-        inputs:
-        - project_path: $BITRISE_SOURCE_DIR
-        - expo_cli_verson: "latest"
-        - user_name: $USER_NAME
-        - password: $PASSWORD
+      - script:
+          title: Clone sample app
+          inputs:
+            - content: git clone -b expo_sdk $SAMPLE_APP_URL . && cd
+      - npm@0.9.1:
+          title: Install node modules for the expo project
+          inputs:
+            - command: install
+      - path::./:
+          title: Step Test
+          run_if: true
+          inputs:
+            - project_path: $BITRISE_SOURCE_DIR
+            - expo_cli_verson: "latest"
+            - user_name: $USER_NAME
+            - password: $PASSWORD
 
   _clear_workdir:
     envs:
     steps:
-    - script:
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -ex
-            cd ${ORIGIN_SOURCE_DIR}
-            rm -rf "./_tmp"
-            mkdir "_tmp"
-    - change-workdir:
-        title: Switch working dir to test / _tmp dir
-        description: |-
-          To prevent step testing issues, like referencing relative
-          files with just './some-file' in the step's code, which would
-          work for testing the step from this directory directly
-          but would break if the step is included in another `bitrise.yml`.
-        run_if: true
-        inputs:
-        - path: ${ORIGIN_SOURCE_DIR}/_tmp
-        - is_create_path: true
+      - script:
+          inputs:
+            - content: |-
+                #!/bin/bash
+                set -ex
+                cd ${ORIGIN_SOURCE_DIR}
+                rm -rf "./_tmp"
+                mkdir "_tmp"
+      - change-workdir:
+          title: Switch working dir to test / _tmp dir
+          description: |-
+            To prevent step testing issues, like referencing relative
+            files with just './some-file' in the step's code, which would
+            work for testing the step from this directory directly
+            but would break if the step is included in another `bitrise.yml`.
+          run_if: true
+          inputs:
+            - path: ${ORIGIN_SOURCE_DIR}/_tmp
+            - is_create_path: true
 
   dep-update:
     title: Dep update
     description: |
       Used for updating bitrise dependencies with dep
     steps:
-    - script:
-        title: Dependency update
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -ex
-            go get -u -v github.com/golang/dep/cmd/dep
-            dep ensure -v
-            dep ensure -v -update
+      - script:
+          title: Dependency update
+          inputs:
+            - content: |-
+                #!/bin/bash
+                set -ex
+                go get -u -v github.com/golang/dep/cmd/dep
+                dep ensure -v
+                dep ensure -v -update
 
   # ----------------------------------------------------------------
   # --- workflows to Share this step into a Step Library
   audit-this-step:
     steps:
-    - script:
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -ex
-            stepman audit --step-yml ./step.yml
+      - script:
+          inputs:
+            - content: |-
+                #!/bin/bash
+                set -ex
+                stepman audit --step-yml ./step.yml

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -30,7 +30,7 @@ workflows:
           inputs:
             - content: git clone $SAMPLE_APP_URL . -b $BRANCH && cd
       - npm@0.9.1:
-          title: Install node modules for the expo project
+          title: Install node modules for the Expo project
           inputs:
             - command: install
       - path::./:
@@ -55,8 +55,8 @@ workflows:
       - change-workdir:
           title: Switch working dir to test / _tmp dir
           description: |-
-            To prevent step testing issues, like referencing relative
-            files with just './some-file' in the step's code, which would
+            To prevent Step testing issues, like referencing relative
+            files with just './some-file' in the Step's code, which would
             work for testing the step from this directory directly
             but would break if the step is included in another `bitrise.yml`.
           run_if: true

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -9,10 +9,6 @@ app:
     - SAMPLE_APP_URL: https://github.com/bitrise-samples/react-native-expo.git
     - BRANCH: "SDK39"
 
-    # Define it in .bitrise.secrets.yml
-    - USER_NAME: $USER_NAME
-    - PASSWORD: $PASSWORD
-
 workflows:
   test:
     before_run:
@@ -23,10 +19,9 @@ workflows:
       - errcheck:
       - go-test:
     after_run:
-      - bare
-      - expo_kit
+      - eject
 
-  bare:
+  eject:
     before_run:
       - _clear_workdir
     steps:
@@ -45,27 +40,6 @@ workflows:
             - project_path: $BITRISE_SOURCE_DIR
             - expo_cli_verson: "latest"
             - override_react_native_version: 0.61.0
-
-  expo_kit:
-    before_run:
-      - _clear_workdir
-    steps:
-      - script:
-          title: Clone sample app
-          inputs:
-            - content: git clone -b expo_sdk $SAMPLE_APP_URL . && cd
-      - npm@0.9.1:
-          title: Install node modules for the expo project
-          inputs:
-            - command: install
-      - path::./:
-          title: Step Test
-          run_if: true
-          inputs:
-            - project_path: $BITRISE_SOURCE_DIR
-            - expo_cli_verson: "latest"
-            - user_name: $USER_NAME
-            - password: $PASSWORD
 
   _clear_workdir:
     envs:

--- a/expo.go
+++ b/expo.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"os"
+	"strings"
+
+	"github.com/bitrise-io/go-utils/command"
+	"github.com/bitrise-io/go-utils/log"
+	"github.com/bitrise-tools/go-steputils/stepconf"
+)
+
+// Expo ...
+type Expo struct {
+	Version string
+	Workdir string
+}
+
+// installExpoCLI runs the install npm command to install the expo-cli
+func (e Expo) installExpoCLI() error {
+	args := []string{"install", "-g"}
+	if e.Version != "latest" {
+		args = append(args, "expo-cli@"+e.Version)
+	} else {
+		args = append(args, "expo-cli")
+	}
+
+	cmd := command.New("npm", args...)
+	cmd.SetStdout(os.Stdout)
+	cmd.SetStderr(os.Stderr)
+
+	log.Donef("$ " + cmd.PrintableCommandArgs())
+	return cmd.Run()
+}
+
+// Login with your Expo account
+func (e Expo) login(userName string, password stepconf.Secret) error {
+	args := []string{"login", "--non-interactive", "-u", userName, "-p", string(password)}
+
+	cmd := command.New("expo", args...)
+	cmd.SetStdout(os.Stdout)
+	cmd.SetStderr(os.Stderr)
+
+	nonFilteredArgs := ("$ " + cmd.PrintableCommandArgs())
+	fileredArgs := strings.Replace(nonFilteredArgs, string(password), "[REDACTED]", -1)
+	log.Printf(fileredArgs)
+
+	return cmd.Run()
+}
+
+// Logout from your Expo account
+func (e Expo) logout() error {
+	cmd := command.New("expo", "logout", "--non-interactive")
+	cmd.SetStdout(os.Stdout)
+	cmd.SetStderr(os.Stderr)
+
+	log.Printf("$ " + cmd.PrintableCommandArgs())
+	return cmd.Run()
+}
+
+// Eject command creates Xcode and Android Studio projects for your app.
+func (e Expo) eject() error {
+	args := []string{"eject", "--non-interactive"}
+
+	cmd := command.New("expo", args...)
+	cmd.SetStdout(os.Stdout)
+	cmd.SetStderr(os.Stderr)
+	if e.Workdir != "" {
+		cmd.SetDir(e.Workdir)
+	}
+
+	log.Donef("$ " + cmd.PrintableCommandArgs())
+	return cmd.Run()
+}
+
+func (e Expo) publish() error {
+	args := []string{"publish", "--non-interactive"}
+
+	cmd := command.New("expo", args...)
+	cmd.SetStdout(os.Stdout)
+	cmd.SetStderr(os.Stderr)
+	if e.Workdir != "" {
+		cmd.SetDir(e.Workdir)
+	}
+
+	log.Donef("$ " + cmd.PrintableCommandArgs())
+	return cmd.Run()
+}

--- a/expo.go
+++ b/expo.go
@@ -28,7 +28,7 @@ func (e Expo) installExpoCLI() error {
 	cmd.SetStdout(os.Stdout)
 	cmd.SetStderr(os.Stderr)
 
-	log.Donef("$ " + cmd.PrintableCommandArgs())
+	log.Donef("$ %s", cmd.PrintableCommandArgs())
 	return cmd.Run()
 }
 

--- a/expo.go
+++ b/expo.go
@@ -53,7 +53,7 @@ func (e Expo) logout() error {
 	cmd.SetStdout(os.Stdout)
 	cmd.SetStderr(os.Stderr)
 
-	log.Printf("$ " + cmd.PrintableCommandArgs())
+	log.Donef("$ %s", cmd.PrintableCommandArgs())
 	return cmd.Run()
 }
 
@@ -68,7 +68,7 @@ func (e Expo) eject() error {
 		cmd.SetDir(e.Workdir)
 	}
 
-	log.Donef("$ " + cmd.PrintableCommandArgs())
+	log.Donef("$ %s", cmd.PrintableCommandArgs())
 	return cmd.Run()
 }
 
@@ -82,6 +82,6 @@ func (e Expo) publish() error {
 		cmd.SetDir(e.Workdir)
 	}
 
-	log.Donef("$ " + cmd.PrintableCommandArgs())
+	log.Donef("$ %s", cmd.PrintableCommandArgs())
 	return cmd.Run()
 }

--- a/main.go
+++ b/main.go
@@ -109,7 +109,9 @@ func main() {
 	log.Donef("Successfully ejected your project")
 
 	if cfg.RunPublish == "yes" {
-		runPublish(e, cfg)
+		if err := runPublish(e, cfg); err != nil {
+			failf("Failed to publish project: %s", err)
+		}
 	}
 
 	if cfg.OverrideReactNativeVersion != "" {
@@ -158,14 +160,14 @@ func main() {
 	}
 }
 
-func runPublish(expo Expo, cfg Config) {
+func runPublish(expo Expo, cfg Config) error {
 	//
 	// Logging in the user to the Expo account
 	fmt.Println()
 	log.Infof("Login to Expo")
 	{
 		if err := expo.login(cfg.UserName, cfg.Password); err != nil {
-			failf("Failed to log in to your provided Expo account, error: %s", err)
+			return fmt.Errorf("failed to log in to your provided Expo account, error: %s", err)
 		}
 	}
 
@@ -186,6 +188,8 @@ func runPublish(expo Expo, cfg Config) {
 
 	// Running publish
 	if err := expo.publish(); err != nil {
-		failf("Failed to publish project: %s", err)
+		return err
 	}
+
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func main() {
 	stepconf.Print(cfg)
 
 	if err := validateUserNameAndpassword(cfg.UserName, cfg.Password); err != nil {
-		failf("Input validation error: %s", err)
+		failf("Input validation failed: %s", err)
 	}
 
 	e := Expo{
@@ -90,7 +90,7 @@ func main() {
 	log.Infof("Install Expo CLI version: %s", cfg.ExpoCLIVersion)
 	{
 		if err := e.installExpoCLI(); err != nil {
-			failf("Failed to install the selected (%s) version for Expo CLI, error: %s", cfg.ExpoCLIVersion, err)
+			failf("Failed to install the selected (%s) version for Expo CLI: %s", cfg.ExpoCLIVersion, err)
 		}
 	}
 
@@ -167,7 +167,7 @@ func runPublish(expo Expo, cfg Config) error {
 	log.Infof("Login to Expo")
 	{
 		if err := expo.login(cfg.UserName, cfg.Password); err != nil {
-			return fmt.Errorf("failed to log in to your provided Expo account, error: %s", err)
+			return fmt.Errorf("failed to log in to your provided Expo account: %s", err)
 		}
 	}
 
@@ -178,7 +178,7 @@ func runPublish(expo Expo, cfg Config) error {
 		log.Infof("Logging out from Expo")
 		{
 			if err := expo.logout(); err != nil {
-				log.Warnf("Failed to log out from your Expo account, error: %s", err)
+				log.Warnf("Failed to log out from your Expo account: %s", err)
 			}
 		}
 	}()

--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func (e Expo) logout() error {
 
 // Eject command creates Xcode and Android Studio projects for your app.
 func (e Expo) eject() error {
-	args := []string{"eject", "--non-interactive", "--eject-method", string(e.Method)}
+	args := []string{"eject", "--non-interactive"}
 
 	cmd := command.New("expo", args...)
 	cmd.SetStdout(os.Stdout)

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/errorutil"
@@ -24,93 +23,6 @@ type Config struct {
 	Password                   stepconf.Secret `env:"password"`
 	RunPublish                 string          `env:"run_publish"`
 	OverrideReactNativeVersion string          `env:"override_react_native_version"`
-}
-
-// EjectMethod if the project is using Expo SDK and you choose the "bare" --eject-method those imports will stop working.
-type EjectMethod string
-
-// const ...
-const (
-	Bare    EjectMethod = "bare"
-	ExpoKit EjectMethod = "expoKit"
-)
-
-// Expo CLI
-type Expo struct {
-	Version string
-	Method  EjectMethod
-	Workdir string
-}
-
-// installExpoCLI runs the install npm command to install the expo-cli
-func (e Expo) installExpoCLI() error {
-	args := []string{"install", "-g"}
-	if e.Version != "latest" {
-		args = append(args, "expo-cli@"+e.Version)
-	} else {
-		args = append(args, "expo-cli")
-	}
-
-	cmd := command.New("npm", args...)
-	cmd.SetStdout(os.Stdout)
-	cmd.SetStderr(os.Stderr)
-
-	log.Donef("$ " + cmd.PrintableCommandArgs())
-	return cmd.Run()
-}
-
-// Login with your Expo account
-func (e Expo) login(userName string, password stepconf.Secret) error {
-	args := []string{"login", "--non-interactive", "-u", userName, "-p", string(password)}
-
-	cmd := command.New("expo", args...)
-	cmd.SetStdout(os.Stdout)
-	cmd.SetStderr(os.Stderr)
-
-	nonFilteredArgs := ("$ " + cmd.PrintableCommandArgs())
-	fileredArgs := strings.Replace(nonFilteredArgs, string(password), "[REDACTED]", -1)
-	log.Printf(fileredArgs)
-
-	return cmd.Run()
-}
-
-// Logout from your Expo account
-func (e Expo) logout() error {
-	cmd := command.New("expo", "logout", "--non-interactive")
-	cmd.SetStdout(os.Stdout)
-	cmd.SetStderr(os.Stderr)
-
-	log.Printf("$ " + cmd.PrintableCommandArgs())
-	return cmd.Run()
-}
-
-// Eject command creates Xcode and Android Studio projects for your app.
-func (e Expo) eject() error {
-	args := []string{"eject", "--non-interactive"}
-
-	cmd := command.New("expo", args...)
-	cmd.SetStdout(os.Stdout)
-	cmd.SetStderr(os.Stderr)
-	if e.Workdir != "" {
-		cmd.SetDir(e.Workdir)
-	}
-
-	log.Donef("$ " + cmd.PrintableCommandArgs())
-	return cmd.Run()
-}
-
-func (e Expo) publish() error {
-	args := []string{"publish", "--non-interactive"}
-
-	cmd := command.New("expo", args...)
-	cmd.SetStdout(os.Stdout)
-	cmd.SetStderr(os.Stderr)
-	if e.Workdir != "" {
-		cmd.SetDir(e.Workdir)
-	}
-
-	log.Donef("$ " + cmd.PrintableCommandArgs())
-	return cmd.Run()
 }
 
 func parsePackageJSON(pth string) (serialized.Object, error) {
@@ -167,23 +79,8 @@ func main() {
 		failf("Input validation error: %s", err)
 	}
 
-	//
-	// Select the --eject-method
-	ejectMethod := Bare
-	fmt.Println()
-	log.Infof("Define --eject-method")
-	{
-		if cfg.UserName != "" {
-			ejectMethod = ExpoKit
-			log.Printf("Expo account credentials have provided => Set the --eject-method to %s", ejectMethod)
-		} else {
-			log.Printf("Expo account credentials have not provided => Set the --eject-method to %s", ejectMethod)
-		}
-	}
-
 	e := Expo{
 		Version: cfg.ExpoCLIVersion,
-		Method:  ejectMethod,
 		Workdir: cfg.Workdir,
 	}
 
@@ -196,39 +93,6 @@ func main() {
 			failf("Failed to install the selected (%s) version for Expo CLI, error: %s", cfg.ExpoCLIVersion, err)
 		}
 	}
-
-	//
-	// Logging in the user to the Expo account
-	fmt.Println()
-	log.Infof("Login to Expo")
-	{
-		switch ejectMethod {
-		case ExpoKit:
-			if err := e.login(cfg.UserName, cfg.Password); err != nil {
-				failf("Failed to log in to your provided Expo account, error: %s", err)
-			}
-		case Bare:
-			log.Printf("--eject-method has been set to bare => Skip...")
-		}
-	}
-
-	//
-	// Logging out the user from the Expo account at the end of the step (even if it fails)
-	defer func() {
-		fmt.Println()
-		log.Infof("Logging out from Expo")
-		{
-			if e.Method == ExpoKit {
-				if err := e.logout(); err != nil {
-					log.Warnf("Failed to log out from your Expo account, error: %s", err)
-				}
-			} else if e.Method == ExpoKit {
-				log.Printf("Logout input was set to false => Skip...")
-			} else {
-				log.Printf("You were not logged in => Skip...")
-			}
-		}
-	}()
 
 	//
 	// Eject project via the Expo CLI
@@ -245,12 +109,7 @@ func main() {
 	log.Donef("Successfully ejected your project")
 
 	if cfg.RunPublish == "yes" {
-		fmt.Println()
-		log.Infof("Running expo publish")
-
-		if err := e.publish(); err != nil {
-			failf("Failed to publish project: %s", err)
-		}
+		runPublish(e, cfg)
 	}
 
 	if cfg.OverrideReactNativeVersion != "" {
@@ -296,5 +155,37 @@ func main() {
 			}
 			failf("%s failed: %s", cmd.PrintableCommandArgs(), err)
 		}
+	}
+}
+
+func runPublish(expo Expo, cfg Config) {
+	//
+	// Logging in the user to the Expo account
+	fmt.Println()
+	log.Infof("Login to Expo")
+	{
+		if err := expo.login(cfg.UserName, cfg.Password); err != nil {
+			failf("Failed to log in to your provided Expo account, error: %s", err)
+		}
+	}
+
+	//
+	// Logging out the user from the Expo account (even if it fails)
+	defer func() {
+		fmt.Println()
+		log.Infof("Logging out from Expo")
+		{
+			if err := expo.logout(); err != nil {
+				log.Warnf("Failed to log out from your Expo account, error: %s", err)
+			}
+		}
+	}()
+
+	fmt.Println()
+	log.Infof("Running expo publish")
+
+	// Running publish
+	if err := expo.publish(); err != nil {
+		failf("Failed to publish project: %s", err)
 	}
 }

--- a/step.yml
+++ b/step.yml
@@ -1,37 +1,37 @@
-title: '[Beta] Expo Eject'
+title: "Expo Eject"
 summary: Creates Xcode and Android Studio projects for your app.
 description: |-
 
-   Expo is a toolchain that allows you to quickly get a React Native app up and running without having to use native code in Xcode or Android Studio. The Expo Eject Step is necessary to eject your app to install any missing native dependencies. Installing the native dependencies is done by our dedicated Steps, such as **Install missing Android SDK components** and **Run CocoaPods install**.
+  Expo is a toolchain that allows you to quickly get a React Native app up and running without having to use native code in Xcode or Android Studio. The Expo Eject Step is necessary to eject your app to install any missing native dependencies. Installing the native dependencies is done by our dedicated Steps, such as **Install missing Android SDK components** and **Run CocoaPods install**.
 
-   ### Configuring the Step
+  ### Configuring the Step
 
-   1. Add the Step to your Workflow after the Step or Steps that install your app's Javascript dependencies (such as **Run npm command** or **Run yarn command**).
+  1. Add the Step to your Workflow after the Step or Steps that install your app's Javascript dependencies (such as **Run npm command** or **Run yarn command**).
 
-   1. Set the **Working directory input field** to the value of your project directory. By default, you do not have to change this.
+  1. Set the **Working directory input field** to the value of your project directory. By default, you do not have to change this.
 
-   1. Specify the Expo CLI version.
+  1. Specify the Expo CLI version.
 
-      The default value is `latest` but you can specify an exact version, such as 3.0.0.
+     The default value is `latest` but you can specify an exact version, such as 3.0.0.
 
-   1. If your app uses an Expo SDK, you must provide the username and password for your Expo account! Without it, the Expo SDK imports will stop working.
+  1. If your app uses an Expo SDK, you must provide the username and password for your Expo account! Without it, the Expo SDK imports will stop working.
 
-   ### Troubleshooting
+  ### Troubleshooting
 
-   If the Expo CLI used the default `--eject-method` and your SDK imports stop working, check your Expo username and password.
+  If the Expo CLI used the default `--eject-method` and your SDK imports stop working, check your Expo username and password.
 
-   Make sure that the Expo CLI version you use is compatible with your app.
+  Make sure that the Expo CLI version you use is compatible with your app.
 
-   ### Useful links
+  ### Useful links
 
-   - [Expo Development CLI](https://docs.expo.io/versions/latest/introduction/installation#local-development-tool-expo-cli)
-   - [Getting started with Expo apps](https://devcenter.bitrise.io/getting-started/getting-started-with-expo-apps/)
+  - [Expo Development CLI](https://docs.expo.io/versions/latest/introduction/installation#local-development-tool-expo-cli)
+  - [Getting started with Expo apps](https://devcenter.bitrise.io/getting-started/getting-started-with-expo-apps/)
 
-   ### Related Steps
+  ### Related Steps
 
-   - [Install React Native](https://www.bitrise.io/integrations/steps/install-react-native)
-   - [Install missing Android SDK components](https://www.bitrise.io/integrations/steps/install-missing-android-tools)
-   - [Run CocoaPods install](https://www.bitrise.io/integrations/steps/cocoapods-install)
+  - [Install React Native](https://www.bitrise.io/integrations/steps/install-react-native)
+  - [Install missing Android SDK components](https://www.bitrise.io/integrations/steps/install-missing-android-tools)
+  - [Run CocoaPods install](https://www.bitrise.io/integrations/steps/cocoapods-install)
 
 website: https://github.com/bitrise-steplib/steps-expo-detach
 source_code_url: https://github.com/bitrise-steplib/steps-expo-detach
@@ -61,9 +61,9 @@ inputs:
         The Expo CLI ejects your project and creates Xcode and Android Studio projects for your app.
 
         [https://docs.expo.io/versions/latest/introduction/installation#local-development-tool-expo-cli](https://docs.expo.io/versions/latest/introduction/installation#local-development-tool-expo-cli)
-        
+
         A couple of examples:
-        
+
         * "3.0.0"
         * latest
       is_required: "true"
@@ -111,8 +111,8 @@ inputs:
 
         files, which are required for the native builds.
       value_options:
-      - "yes"
-      - "no"
+        - "yes"
+        - "no"
   - override_react_native_version:
     opts:
       title: React Native version to set in package.json

--- a/step.yml
+++ b/step.yml
@@ -88,7 +88,7 @@ inputs:
       description: |-
         Should the step run `expo publish` after eject?
 
-        If set to "yes" both `user_name` and `password` are required to be provided.
+        If set to "yes" both, `user_name` and `password` are required to be provided.
       value_options:
         - "yes"
         - "no"

--- a/step.yml
+++ b/step.yml
@@ -68,14 +68,18 @@ inputs:
       title: Username for Expo
       summary: Username for Expo
       description: |-
-        Your account's username for `https://expo.io/` . Required if `run_publish` is set to "yes".
+        Your account's username for `https://expo.io/` .
+
+        Required if `run_publish` is set to "yes".
         **NOTE:** You need to use your username and not your e-mail address.
   - password: ""
     opts:
       title: Password for your Expo account
       summary: Password for your Expo account.
       description: |-
-        Your password for `https://expo.io/` . Required if `run_publish` is set to "yes".
+        Your password for `https://expo.io/` .
+
+        Required if `run_publish` is set to "yes".
       is_sensitive: true
   - run_publish: "no"
     opts:

--- a/step.yml
+++ b/step.yml
@@ -14,11 +14,7 @@ description: |-
 
      The default value is `latest` but you can specify an exact version, such as 3.0.0.
 
-  1. If your app uses an Expo SDK, you must provide the username and password for your Expo account! Without it, the Expo SDK imports will stop working.
-
   ### Troubleshooting
-
-  If the Expo CLI used the default `--eject-method` and your SDK imports stop working, check your Expo username and password.
 
   Make sure that the Expo CLI version you use is compatible with your app.
 
@@ -72,27 +68,14 @@ inputs:
       title: Username for Expo
       summary: Username for Expo
       description: |-
-        Your account's username for `https://expo.io/` .
-
-        In case of React Native project __using Expo Kit__ library (any .js file imports expo),  
-        the `user_name` and `password` inputs are __required__.
-
-        If you provide these inputs the step will run: `expo eject --eject-method expoKit`,  
-        otherwise: `expo eject --eject-method bare`.
-
+        Your account's username for `https://expo.io/` . Required if `run_publish` is set to "yes".
         **NOTE:** You need to use your username and not your e-mail address.
   - password: ""
     opts:
       title: Password for your Expo account
       summary: Password for your Expo account.
       description: |-
-        Your password for `https://expo.io/` .
-
-        In case of React Native project __using Expo Kit__ library (any .js file imports expo),  
-        the `user_name` and `password` inputs are __required__.
-
-        If you provide these inputs the step will run: `expo eject --eject-method expoKit`,  
-        otherwise: `expo eject --eject-method bare`.
+        Your password for `https://expo.io/` . Required if `run_publish` is set to "yes".
       is_sensitive: true
   - run_publish: "no"
     opts:
@@ -101,15 +84,7 @@ inputs:
       description: |-
         Should the step run `expo publish` after eject?
 
-        In case of React Native project using Expo Kit library (any .js file imports expo),  
-        `expo publis` command generates the:
-
-        - ./android/app/src/main/assets/shell-app-manifest.json
-        - ./android/app/src/main/assets/shell-app.bundle
-        - ./ios/bitriseexpokit/Supporting/shell-app-manifest.json
-        - ./ios/bitriseexpokit/Supporting/shell-app.bundle
-
-        files, which are required for the native builds.
+        If set to "yes" both `user_name` and `password` are required to be provided.
       value_options:
         - "yes"
         - "no"


### PR DESCRIPTION
Should fix #12 and #7.

**Description**
Updating the step to reflect the changes in expo cli made to the `eject` command. `expo cli` no longer support using the `--eject-method` parameter.

**Changes:**

- Removed `[Beta]` tag from `step.yml` title and README.md.
- Removed unsupported `--eject-method`.
- Update the [sample app](https://github.com/bitrise-io/react-native-expo) to use [SDK39](https://github.com/bitrise-io/react-native-expo/tree/SDK39).
- Extracted `Expo` struct to a separate `expo.go` file.
- `bitrise.yml`
  - removed `expo_kit ` workflow as expoKit is no longer supported.
  - renamed `bare` workflow to `eject`
  - file has a lot of format changes
- Updated `step.yml`