### PR TITLE
Run expo login before eject

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -9,6 +9,9 @@ app:
     - SAMPLE_APP_URL: https://github.com/bitrise-samples/react-native-expo.git
     - BRANCH: "SDK39"
 
+    - ANDROIDMANIFEST_PATH: "$ORIGIN_SOURCE_DIR/_tmp/android/app/src/main/AndroidManifest.xml"
+    - EXPO_UPDATE_URL_KEY: "expo.modules.updates.EXPO_UPDATE_URL"
+
 workflows:
   test:
     before_run:
@@ -19,11 +22,13 @@ workflows:
       - errcheck:
       - go-test:
     after_run:
-      - eject
+      - test-eject
 
-  eject:
+  test-eject:
     before_run:
       - _clear_workdir
+    after_run:
+      - validate-output
     steps:
       - script:
           title: Clone sample app
@@ -37,12 +42,27 @@ workflows:
           title: Step Test
           run_if: true
           inputs:
+            - user_name: $USER_NAME
+            - password: $PASSWORD
             - project_path: $BITRISE_SOURCE_DIR
             - expo_cli_verson: "latest"
             - override_react_native_version: 0.61.0
 
+  validate-output:
+    title: Validate output
+    steps:
+      - script:
+          title: Validate that expo.modules.updates.EXPO_UPDATE_URL is present in AndroidManifest.xml
+          inputs:
+            - content: |-
+                #!/bin/bash
+                set -ex
+                if ! grep -q $EXPO_UPDATE_URL_KEY $ANDROIDMANIFEST_PATH; then
+                  echo "$EXPO_UPDATE_URL_KEY is not found in $ANDROIDMANIFEST_PATH"
+                  exit 1
+                fi
+
   _clear_workdir:
-    envs:
     steps:
       - script:
           inputs:

--- a/main.go
+++ b/main.go
@@ -19,8 +19,8 @@ import (
 type Config struct {
 	Workdir                    string          `env:"project_path,dir"`
 	ExpoCLIVersion             string          `env:"expo_cli_verson,required"`
-	UserName                   string          `env:"user_name"`
-	Password                   stepconf.Secret `env:"password"`
+	UserName                   string          `env:"user_name,required"`
+	Password                   stepconf.Secret `env:"password,required"`
 	RunPublish                 string          `env:"run_publish"`
 	OverrideReactNativeVersion string          `env:"override_react_native_version"`
 }
@@ -95,6 +95,28 @@ func main() {
 	}
 
 	//
+	// Logging in the user to the Expo account
+	fmt.Println()
+	log.Infof("Login to Expo")
+	{
+		if err := e.login(cfg.UserName, cfg.Password); err != nil {
+			failf("Failed to log in to your provided Expo account: %s", err)
+		}
+	}
+
+	//
+	// Logging out the user from the Expo account (even if it fails)
+	defer func() {
+		fmt.Println()
+		log.Infof("Logging out from Expo")
+		{
+			if err := e.logout(); err != nil {
+				log.Warnf("Failed to log out from your Expo account: %s", err)
+			}
+		}
+	}()
+
+	//
 	// Eject project via the Expo CLI
 	fmt.Println()
 	log.Infof("Eject project")
@@ -161,28 +183,6 @@ func main() {
 }
 
 func runPublish(expo Expo, cfg Config) error {
-	//
-	// Logging in the user to the Expo account
-	fmt.Println()
-	log.Infof("Login to Expo")
-	{
-		if err := expo.login(cfg.UserName, cfg.Password); err != nil {
-			return fmt.Errorf("failed to log in to your provided Expo account: %s", err)
-		}
-	}
-
-	//
-	// Logging out the user from the Expo account (even if it fails)
-	defer func() {
-		fmt.Println()
-		log.Infof("Logging out from Expo")
-		{
-			if err := expo.logout(); err != nil {
-				log.Warnf("Failed to log out from your Expo account: %s", err)
-			}
-		}
-	}()
-
 	fmt.Println()
 	log.Infof("Running expo publish")
 

--- a/step.yml
+++ b/step.yml
@@ -70,25 +70,22 @@ inputs:
       description: |-
         Your account's username for `https://expo.io/` .
 
-        Required if `run_publish` is set to "yes".
         **NOTE:** You need to use your username and not your e-mail address.
+      is_required: "true"
   - password: ""
     opts:
       title: Password for your Expo account
       summary: Password for your Expo account.
       description: |-
         Your password for `https://expo.io/` .
-
-        Required if `run_publish` is set to "yes".
       is_sensitive: true
+      is_required: "true"
   - run_publish: "no"
     opts:
       title: Run expo publish after eject?
       summary: Should the step run `expo publish` after eject?
       description: |-
         Should the step run `expo publish` after eject?
-
-        If set to "yes" both, `user_name` and `password` are required to be provided.
       value_options:
         - "yes"
         - "no"


### PR DESCRIPTION
### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires MAJOR [version update](https://semver.org/)

### Context

We need to run `expo login` before the project is ejected to get the required `expo.modules.updates.EXPO_UPDATE_URL` field in AndroidManifest.xml filled. Breaking change: `user_name` and `password` inputs are now required inputs.

Resolves: #14 
Resolves: [STEP-594](https://bitrise.atlassian.net/browse/STEP-594)

### Changes

- Make `user_name` and `password` inputs required.
- Extend e2e test to validate that expo.modules.updates.EXPO_UPDATE_URL is present in AndroidManifest.xml.
