### PR TITLE
Login to expo before eject

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -9,6 +9,9 @@ app:
     - SAMPLE_APP_URL: https://github.com/bitrise-samples/react-native-expo.git
     - BRANCH: "SDK39"
 
+    - ANDROIDMANIFEST_PATH: "$ORIGIN_SOURCE_DIR/_tmp/android/app/src/main/AndroidManifest.xml"
+    - EXPO_UPDATE_URL_KEY: "expo.modules.updates.EXPO_UPDATE_URL"
+
 workflows:
   test:
     before_run:
@@ -19,11 +22,13 @@ workflows:
       - errcheck:
       - go-test:
     after_run:
-      - eject
+      - test-eject
 
-  eject:
+  test-eject:
     before_run:
       - _clear_workdir
+    after_run:
+      - validate-output
     steps:
       - script:
           title: Clone sample app
@@ -40,9 +45,24 @@ workflows:
             - project_path: $BITRISE_SOURCE_DIR
             - expo_cli_verson: "latest"
             - override_react_native_version: 0.61.0
+            - user_name: $USER_NAME
+            - password: $PASSWORD
+
+  validate-output:
+    title: Validate output
+    steps:
+      - script:
+          title: Validate that expo.modules.updates.EXPO_UPDATE_URL is present in AndroidManifest.xml
+          inputs:
+            - content: |-
+                #!/bin/bash
+                set -ex
+                if ! grep -q $EXPO_UPDATE_URL_KEY $ANDROIDMANIFEST_PATH; then
+                  echo "$EXPO_UPDATE_URL_KEY is not found in $ANDROIDMANIFEST_PATH"
+                  exit 1
+                fi
 
   _clear_workdir:
-    envs:
     steps:
       - script:
           inputs:

--- a/main.go
+++ b/main.go
@@ -157,7 +157,7 @@ func detach(e Expo, cfg Config) error {
 		packages["dependencies"] = deps
 
 		if err := savePackageJSON(packages, packageJSONPth); err != nil {
-			failfDefered(func() { logout(e) }, err.Error())
+			return err
 		}
 
 		//

--- a/main.go
+++ b/main.go
@@ -62,12 +62,7 @@ func validateUserNameAndpassword(userName string, password stepconf.Secret) erro
 }
 
 func failf(format string, v ...interface{}) {
-	failfDefered(func() {}, format, v)
-}
-
-func failfDefered(defered func(), format string, v ...interface{}) {
 	log.Errorf(format, v...)
-	defered()
 	os.Exit(1)
 }
 

--- a/step.yml
+++ b/step.yml
@@ -10,6 +10,8 @@ description: |-
 
   1. Set the **Working directory input field** to the value of your project directory. By default, you do not have to change this.
 
+  1. Provide your Expo username and password if you are using an Expo module that requires loging in before ejecting your app. Please refer to the [Expo documentation](https://docs.expo.io/) for more information.
+
   1. Specify the Expo CLI version.
 
      The default value is `latest` but you can specify an exact version, such as 3.0.0.
@@ -68,7 +70,7 @@ inputs:
       title: Username for Expo
       summary: Username for Expo
       description: |-
-        Your account's username for `https://expo.io/` .
+        Your account's username for `https://expo.io/` . If provided `expo login` will be run before eject.
 
         Required if `run_publish` is set to "yes".
         **NOTE:** You need to use your username and not your e-mail address.
@@ -77,7 +79,7 @@ inputs:
       title: Password for your Expo account
       summary: Password for your Expo account.
       description: |-
-        Your password for `https://expo.io/` .
+        Your password for `https://expo.io/` . If provided `expo login` will be run before eject.
 
         Required if `run_publish` is set to "yes".
       is_sensitive: true


### PR DESCRIPTION
### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires MINOR [version update](https://semver.org/)

### Context

Some expo modules require `expo login` to be run before ejecting. If both `user_name` and `password` is provided we will 
run `expo login` to support this.

Resolves: #14 
Resolves: [STEP-594](https://bitrise.atlassian.net/browse/STEP-594)

### Changes

- Run `expo login` when `user_name` and `password` is provided.
- Run `expo logout` at the end of the step or when the step fails.
- Extend e2e test to validate that expo.modules.updates.EXPO_UPDATE_URL is present in AndroidManifest.xml.
- Update `step.yml`
